### PR TITLE
Create simple Qt calendar project

### DIFF
--- a/Agenda.pro
+++ b/Agenda.pro
@@ -1,0 +1,14 @@
+QT += core gui widgets
+CONFIG += c++11
+TARGET = Agenda
+TEMPLATE = app
+SOURCES += \
+    main.cpp \
+    mainwindow.cpp
+HEADERS += \
+    mainwindow.h
+FORMS += mainwindow.ui
+RESOURCES += resources.qrc
+
+# For storing events in a JSON file
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# Projet-Desktop-agenda
+# Agenda (Qt Example)
+
+This is a simple desktop agenda application built with Qt Widgets.
+
+It allows you to select dates from a calendar, add events for each day, and
+stores them in a JSON file (`agenda_events.json`) in your home directory.
+
+The project uses qmake and can be opened directly in Qt Creator.
+
+## Building
+
+1. Open `Agenda.pro` with Qt Creator.
+2. Configure the project with your installed Qt kit.
+3. Build and run from Qt Creator.
+
+Events will be saved automatically when you close the application. If you share
+the JSON file between machines, you can emulate a basic shared agenda.

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,10 @@
+#include "mainwindow.h"
+#include <QApplication>
+
+int main(int argc, char *argv[])
+{
+    QApplication a(argc, argv);
+    MainWindow w;
+    w.show();
+    return a.exec();
+}

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,0 +1,103 @@
+#include "mainwindow.h"
+#include <QVBoxLayout>
+#include <QFile>
+#include <QDir>
+
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent), ui(nullptr)
+{
+    QWidget *central = new QWidget(this);
+    setCentralWidget(central);
+
+    calendar = new QCalendarWidget(this);
+    eventTable = new QTableWidget(this);
+    eventTable->setColumnCount(1);
+    eventTable->setHorizontalHeaderLabels(QStringList() << "Ev\xC3\xA9nements");
+
+    eventEdit = new QLineEdit(this);
+    addButton = new QPushButton(tr("Ajouter"), this);
+    connect(addButton, &QPushButton::clicked, this, &MainWindow::onAddEvent);
+
+    connect(calendar, &QCalendarWidget::selectionChanged, [this]() {
+        onDateChanged(calendar->selectedDate());
+    });
+
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->addWidget(calendar);
+    layout->addWidget(eventTable);
+
+    QHBoxLayout *hl = new QHBoxLayout;
+    hl->addWidget(eventEdit);
+    hl->addWidget(addButton);
+    layout->addLayout(hl);
+
+    central->setLayout(layout);
+
+    loadEvents();
+    onDateChanged(calendar->selectedDate());
+}
+
+MainWindow::~MainWindow()
+{
+    saveEvents();
+}
+
+void MainWindow::onDateChanged(const QDate &date)
+{
+    Q_UNUSED(date);
+    refreshEventList();
+}
+
+void MainWindow::onAddEvent()
+{
+    QString text = eventEdit->text().trimmed();
+    if (!text.isEmpty()) {
+        events[calendar->selectedDate()].append(text);
+        eventEdit->clear();
+        refreshEventList();
+    }
+}
+
+void MainWindow::refreshEventList()
+{
+    eventTable->clearContents();
+    QStringList list = events.value(calendar->selectedDate());
+    eventTable->setRowCount(list.size());
+    for (int i = 0; i < list.size(); ++i) {
+        QTableWidgetItem *item = new QTableWidgetItem(list.at(i));
+        eventTable->setItem(i, 0, item);
+    }
+}
+
+void MainWindow::loadEvents()
+{
+    QFile file(QDir::homePath() + "/agenda_events.json");
+    if (!file.open(QIODevice::ReadOnly))
+        return;
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    QJsonObject obj = doc.object();
+    for (const QString &key : obj.keys()) {
+        QDate date = QDate::fromString(key, Qt::ISODate);
+        QJsonArray arr = obj.value(key).toArray();
+        QStringList list;
+        for (const QJsonValue &val : arr)
+            list.append(val.toString());
+        events[date] = list;
+    }
+}
+
+void MainWindow::saveEvents()
+{
+    QFile file(QDir::homePath() + "/agenda_events.json");
+    if (!file.open(QIODevice::WriteOnly))
+        return;
+    QJsonObject obj;
+    for (auto it = events.begin(); it != events.end(); ++it) {
+        QJsonArray arr;
+        for (const QString &ev : it.value())
+            arr.append(ev);
+        obj.insert(it.key().toString(Qt::ISODate), arr);
+    }
+    QJsonDocument doc(obj);
+    file.write(doc.toJson());
+}

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -1,0 +1,42 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QMainWindow>
+#include <QCalendarWidget>
+#include <QTableWidget>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QJsonObject>
+#include <QJsonDocument>
+#include <QJsonArray>
+
+QT_BEGIN_NAMESPACE
+namespace Ui { class MainWindow; }
+QT_END_NAMESPACE
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+
+public:
+    MainWindow(QWidget *parent = nullptr);
+    ~MainWindow();
+
+private slots:
+    void onDateChanged(const QDate &date);
+    void onAddEvent();
+
+private:
+    void loadEvents();
+    void saveEvents();
+    void refreshEventList();
+
+    Ui::MainWindow *ui;
+    QCalendarWidget *calendar;
+    QTableWidget *eventTable;
+    QLineEdit *eventEdit;
+    QPushButton *addButton;
+
+    QMap<QDate, QStringList> events;
+};
+#endif // MAINWINDOW_H

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Agenda</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QVBoxLayout" name="verticalLayout"/>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/resources.qrc
+++ b/resources.qrc
@@ -1,0 +1,4 @@
+<RCC>
+    <qresource prefix="/">
+    </qresource>
+</RCC>


### PR DESCRIPTION
## Summary
- add a qmake project for a simple calendar application
- implement MainWindow to handle events
- store events in a JSON file
- provide a simple README with build instructions

## Testing
- `qmake --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686789506144832fb15b8a81db7a9d31